### PR TITLE
Added blog.title variable to the two themes

### DIFF
--- a/web/themes/bootstrap3-default/layout.html.twig
+++ b/web/themes/bootstrap3-default/layout.html.twig
@@ -9,7 +9,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
 
-    <title>Steem Press Blog Blog</title>
+    <title>{{ blog.title }}</title>
 
     <!-- Bootstrap Core CSS -->
     <link href="/themes/bootstrap3-default/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">

--- a/web/themes/foundation6-default/layout.html.twig
+++ b/web/themes/foundation6-default/layout.html.twig
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>Homepage</title>
+        <title>{{ blog.title }}</title>
         <link rel="stylesheet" href="/themes/foundation6-default/css/foundation.css">
         <link rel="stylesheet" href="/themes/foundation6-default/css/main.css">
         <script src="/themes/foundation6-default/js/modernizr-2.6.2.min.js"></script>


### PR DESCRIPTION
Hey @aaroncox -- neither of the themes were using the blog.title variable. Here's a pull that fixes that.

As well, the title tag should really have something like (pseudocode):

```
if (post.title) then {{ post.title }} – endif
blog.title 
```

But I'll need to dig in further to get to that. If we can mark up these two default themes with variables, it will provide a good template.
